### PR TITLE
Expose MSIZE instruction

### DIFF
--- a/src/Evm.sol
+++ b/src/Evm.sol
@@ -16,7 +16,7 @@ library EvmLib {
     using BinOps for Stack;
     using Builtins for Stack;
     using ControlFlow for Stack;
-    
+
     using MemoryLib for Memory;
 
     using StorageLib for Storage;
@@ -95,12 +95,13 @@ library EvmLib {
 
         ops.unsafe_set(0x54, intoPtr(StorageLib.sload));
         ops.unsafe_set(0x55, intoPtr(StorageLib.sstore));
+        ops.unsafe_set(0x59, intoPtr(MemoryLib.msize));
 
         ops.unsafe_set(0x5a, intoPtr(Builtins._gas));
     }
 
     function setupCompressedOpTable() internal view returns (Array ops) {
-        // only use 16 bits 
+        // only use 16 bits
         ops = ArrayLib.newArray(6);
         // set capacity
         assembly ("memory-safe") {
@@ -174,10 +175,11 @@ library EvmLib {
         fourth = compress(fourth, 0x48, intoPtr(EvmContextLib.basefee));
         ops.unsafe_set(4, fourth);
 
-        
+
 
         fifth = compress(fifth, 0x54, intoPtr(StorageLib.sload));
         fifth = compress(fifth, 0x55, intoPtr(StorageLib.sstore));
+        fifth = compress(fifth, 0x59, intoPtr(MemoryLib.msize));
 
         fifth = compress(fifth, 0x5a, intoPtr(Builtins._gas));
         ops.unsafe_set(5, fifth);
@@ -212,7 +214,7 @@ library EvmLib {
 
         // stack capacity unlikely to surpass 32 words
         Stack stack = StackLib.newStack(stackSizeHint);
-        
+
         // creates a storage map
         Storage store = StorageLib.newStorage(storageSizeHint);
 
@@ -270,7 +272,7 @@ library EvmLib {
                     } else {
                         // pc, 0x58
                         stack = stack.push(i, 0);
-                    } 
+                    }
                 } else if (op == 0x38) {
                     // codesize
                     stack = stack.push(bcodeLen, 0);
@@ -321,11 +323,11 @@ library EvmLib {
             pop(
                 staticcall(
                     gas(), // pass gas
-                    0x04,  // call identity precompile address 
+                    0x04,  // call identity precompile address
                     add(start, offset), // arg offset == pointer to calldata
                     size,  // arg size
                     add(and(mem, ptr_mask), destOffset), // set return buffer to memory ptr + destination offset
-                    size   // identity just returns the bytes of the input so equal to argsize 
+                    size   // identity just returns the bytes of the input so equal to argsize
                 )
             )
         }

--- a/src/test/Evm.t.sol
+++ b/src/test/Evm.t.sol
@@ -101,6 +101,14 @@ contract EvmTest is DSTest {
         assertEq(r, 1);
     }
 
+    function testMsizeInitiallyZero() public {
+        Evm evm;
+        (bool succ, bytes memory ret) = evm.evaluate(hex"5960005260206000f3", 2, 0, 1);
+        assertTrue(succ);
+        (uint256 r) = abi.decode(ret, (uint256));
+        assertEq(r, 0);
+    }
+
     function testCtx() public {
         Mapping balances = MappingLib.newMapping(1);
         balances.insert(bytes32(uint256(0x1339)), 1e18);
@@ -147,7 +155,7 @@ contract EvmTest is DSTest {
         // bytes memory bf    = hex"4861014052";
         // bytes memory retur = hex"6101406000F3";
 
-        
+
         bytes memory bytecode = hex"32600052336020523060405234606052416080524260a0524360c0524560e0524461010052466101205248610140526101606000F3";
 
 


### PR DESCRIPTION
I also wanted to add a test to verify that MSIZE returns the expanded size on access but I couldn't get them to pass, it looks like MSIZE always returns 0?

FYI here is the test:

```solidity
    function testMsizeExpandedOnAccess() public {
        Evm evm;
        (bool succ, bytes memory ret) = evm.evaluate(hex"60806040525960005260206000f3", 2, 0, 1);
        assertTrue(succ);

        console2.logBytes(ret);
        (uint256 r) = abi.decode(ret, (uint256));
        assertEq(r, 0x60);
    }
```